### PR TITLE
Add shortcut for Reply command.

### DIFF
--- a/Nostalgy4MailApp/SearchManager.m
+++ b/Nostalgy4MailApp/SearchManager.m
@@ -122,6 +122,11 @@
     [viewer archiveMessages:nil];
 }
 
+- (IBAction)replyMessage:(id)sender {
+  MessageViewer *viewer = [self frontmostMessageViewer];
+  [viewer replyMessage:nil];
+}
+
 - (IBAction)replyAllMessage:(id)sender {
     MessageViewer *viewer = [self frontmostMessageViewer];
     [viewer replyAllMessage:nil];

--- a/Nostalgy4MailApp/SearchManager.xib
+++ b/Nostalgy4MailApp/SearchManager.xib
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16B2327e" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment version="1050" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SearchManager">
@@ -41,10 +41,16 @@
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="VUk-TO-fiz"/>
-                <menuItem title="Reply All" keyEquivalent="r" id="iz1-BE-8dI">
+                <menuItem title="Reply" keyEquivalent="r" id="iz1-BE-8dI">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
-                        <action selector="replyAllMessage:" target="-2" id="rIx-4d-x97"/>
+                        <action selector="replyMessage:" target="-2" id="PhT-e2-Gba"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Reply All" keyEquivalent="a" id="3fz-61-Tqh">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="replyAllMessage:" target="-2" id="0tv-eE-BfF"/>
                     </connections>
                 </menuItem>
                 <menuItem title="Forward" keyEquivalent="f" id="VCM-02-nRT">

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ in progress. Tested with Mail for 10.11, 10.12 and 10.12.2 Beta.
 <table>
   <tr><th>Key</th><th>Action</th></tr>
   <tr><td>c</td><td>Compose new message</td></tr>
-  <tr><td>r</td><td>Reply All</td></tr>
+  <tr><td>r</td><td>Reply</td></tr>
+  <tr><td>a</td><td>Reply All</td></tr>
   <tr><td>f</td><td>Forward</td></tr>
   <tr><td>s</td><td>Flag (Star)</td></tr>
   <tr><td>e</td><td>Archive</td></tr>


### PR DESCRIPTION
Adds shortcut R for Reply (to sender only) in addition to the existing Reply All. 
Changes the shortcut for Reply All to A as it used R before but Google Mail uses R for Reply and A for Reply All. (See https://support.google.com/mail/answer/6594)